### PR TITLE
Parallelization support via future.apply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ inst/doc
 renv
 renv.lock
 docs
+tests/spelling.Rout.save

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dcurves
 Title: Decision Curve Analysis for Model Evaluation
-Version: 0.4.0.9000
+Version: 0.4.0.9000-1
 Authors@R: 
     c(person(given = "Daniel D.",
            family = "Sjoberg",
@@ -46,7 +46,9 @@ Suggests:
     rmarkdown (>= 2.7),
     spelling (>= 2.2),
     testthat (>= 3.0.2),
-    tidyr (>= 1.1.3)
+    tidyr (>= 1.1.3),
+    future,
+    future.apply
 VignetteBuilder: 
     knitr
 ByteCompile: true
@@ -56,4 +58,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dcurves
 Title: Decision Curve Analysis for Model Evaluation
-Version: 0.4.0.9000-1
+Version: 0.4.0.9001
 Authors@R: 
     c(person(given = "Daniel D.",
            family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dcurves (development version)
 
+* Add support for parallel calculation of test consequences via `future.apply` package. (#8 by @ck37)
+
 # dcurves 0.4.0
 
 * The net interventions avoided figures have new defaults (breaking change):

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # dcurves (development version)
 
-* Add support for parallel calculation of test consequences via `future.apply` package. (#8 by @ck37)
+* Add support for parallel calculation of test consequences via `future.apply` package. (#25 by @ck37)
 
 # dcurves 0.4.0
 

--- a/R/dca.r
+++ b/R/dca.r
@@ -76,7 +76,9 @@
 #'
 #' # use multiple cores
 #' future::plan("multisession", workers = 2)
-#' dca(cancer ~ cancerpredmarker, data = df_binary, parallel = TRUE)
+#' dca(cancer ~ cancerpredmarker, data = df_binary, thresholds = seq(0, 0.2, by = 0.05),
+#'    parallel = TRUE)
+#' future::plan("sequential") # stop parallelization
 dca <- function(formula, data, thresholds = seq(0, 0.99, by = 0.01),
                 label = NULL, harm = NULL, as_probability = character(),
                 time = NULL, prevalence = NULL, parallel = FALSE) {

--- a/R/dca.r
+++ b/R/dca.r
@@ -32,6 +32,10 @@
 #' @param prevalence When `NULL`, the prevalence is estimated from `data=`.
 #' If the data passed is a case-control set, the population prevalence
 #' may be set with this argument.
+#' @param parallel Set to TRUE (default FALSE) to have test consequences
+#' use future.apply to take advantage of a parallel processing backend (if
+#' configured), parallelizing across models. See vignette or ?dca for example
+#' code.
 #'
 #' @section as_probability argument:
 #' While the `as_probability=` argument can be used to convert a marker to the
@@ -69,9 +73,13 @@
 #'
 #' # calculate DCA with time to event endpoint
 #' dca(Surv(ttcancer, cancer) ~ cancerpredmarker, data = df_surv, time = 1)
+#'
+#' # use multiple cores
+#' future::plan("multisession", workers = 2)
+#' dca(cancer ~ cancerpredmarker, data = df_binary, parallel = TRUE)
 dca <- function(formula, data, thresholds = seq(0, 0.99, by = 0.01),
                 label = NULL, harm = NULL, as_probability = character(),
-                time = NULL, prevalence = NULL) {
+                time = NULL, prevalence = NULL, parallel = FALSE) {
   # checking inputs ------------------------------------------------------------
   if (!is.data.frame(data))
     stop("`data=` must be a data frame", call. = FALSE)
@@ -127,7 +135,8 @@ dca <- function(formula, data, thresholds = seq(0, 0.99, by = 0.01),
       label = label,
       time = time,
       prevalence = prevalence,
-      harm = harm
+      harm = harm,
+      parallel = parallel
     )
 
   # return results -------------------------------------------------------------

--- a/R/test_consequences.R
+++ b/R/test_consequences.R
@@ -86,7 +86,7 @@ test_consequences_data_frame <- function(model_frame, outcome_name, outcome_type
 
   # Initial diagnostic stat calculation can be slow with large datasets,
   # and/or many models, so give the option for parallelization.
-  if (parallel && "future.apply" %in% rownames(utils::installed.packages())) {
+  if (parallel && requireNamespace("future.apply", quietly = TRUE)) {
     lapply_fun = future.apply::future_lapply
   } else {
     lapply_fun = lapply

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -23,6 +23,7 @@ ggplot
 loess
 miscalibration
 multivariable
+parallelizing
 tibble
 unsmoothed
 www

--- a/man/dca.Rd
+++ b/man/dca.Rd
@@ -12,7 +12,8 @@ dca(
   harm = NULL,
   as_probability = character(),
   time = NULL,
-  prevalence = NULL
+  prevalence = NULL,
+  parallel = FALSE
 )
 }
 \arguments{
@@ -38,6 +39,11 @@ assessment is made}
 \item{prevalence}{When \code{NULL}, the prevalence is estimated from \verb{data=}.
 If the data passed is a case-control set, the population prevalence
 may be set with this argument.}
+
+\item{parallel}{Set to TRUE (default FALSE) to have test consequences
+use future.apply to take advantage of a parallel processing backend (if
+configured), parallelizing across models. See vignette or ?dca for example
+code.}
 }
 \value{
 List including net benefit of each variable
@@ -91,6 +97,10 @@ dca(cancer ~ cancerpredmarker + marker,
 
 # calculate DCA with time to event endpoint
 dca(Surv(ttcancer, cancer) ~ cancerpredmarker, data = df_surv, time = 1)
+
+# use multiple cores
+future::plan("multisession", workers = 2)
+dca(cancer ~ cancerpredmarker, data = df_binary, parallel = TRUE)
 }
 \seealso{
 \code{\link[=net_intervention_avoided]{net_intervention_avoided()}}, \code{\link[=standardized_net_benefit]{standardized_net_benefit()}}, \code{\link[=plot.dca]{plot.dca()}},

--- a/man/dca.Rd
+++ b/man/dca.Rd
@@ -100,7 +100,9 @@ dca(Surv(ttcancer, cancer) ~ cancerpredmarker, data = df_surv, time = 1)
 
 # use multiple cores
 future::plan("multisession", workers = 2)
-dca(cancer ~ cancerpredmarker, data = df_binary, parallel = TRUE)
+dca(cancer ~ cancerpredmarker, data = df_binary, thresholds = seq(0, 0.2, by = 0.05),
+   parallel = TRUE)
+future::plan("sequential") # stop parallelization
 }
 \seealso{
 \code{\link[=net_intervention_avoided]{net_intervention_avoided()}}, \code{\link[=standardized_net_benefit]{standardized_net_benefit()}}, \code{\link[=plot.dca]{plot.dca()}},

--- a/man/test_consequences.Rd
+++ b/man/test_consequences.Rd
@@ -12,7 +12,8 @@ test_consequences(
   thresholds = seq(0, 1, by = 0.25),
   label = NULL,
   time = NULL,
-  prevalence = NULL
+  prevalence = NULL,
+  parallel = FALSE
 )
 }
 \arguments{
@@ -35,6 +36,11 @@ assessment is made}
 \item{prevalence}{When \code{NULL}, the prevalence is estimated from \verb{data=}.
 If the data passed is a case-control set, the population prevalence
 may be set with this argument.}
+
+\item{parallel}{Set to TRUE (default FALSE) to have test consequences
+use future.apply to take advantage of a parallel processing backend (if
+configured), parallelizing across models. See vignette or ?dca for example
+code.}
 }
 \value{
 a tibble with test consequences

--- a/tests/testthat/test-test_consequences.R
+++ b/tests/testthat/test-test_consequences.R
@@ -48,6 +48,7 @@ test_that("test_consequences() works", {
       future::plan("multisession", workers = 2)
       test_consequences(formula = cancer ~ cancerpredmarker + marker,
                         data = df_binary, parallel = TRUE)
+      future::plan("sequential") # stop parallelization
     }
   })
 })

--- a/tests/testthat/test-test_consequences.R
+++ b/tests/testthat/test-test_consequences.R
@@ -44,7 +44,8 @@ test_that("test_consequences() works", {
   )
 
   expect_no_error({
-    if ("future.apply" %in% rownames(utils::installed.packages())) {
+    # This test is only run if the future.apply package is installed.
+    if (requireNamespace("future.apply", quietly = TRUE)) {
       future::plan("multisession", workers = 2)
       test_consequences(formula = cancer ~ cancerpredmarker + marker,
                         data = df_binary, parallel = TRUE)

--- a/tests/testthat/test-test_consequences.R
+++ b/tests/testthat/test-test_consequences.R
@@ -42,4 +42,12 @@ test_that("test_consequences() works", {
          lr_pos  = (a / (a + c)) / (1 - (d / (b + d))),
          lr_neg  = (1 - (a / (a + c))) / (d / (b + d)))
   )
+
+  expect_no_error({
+    if ("future.apply" %in% rownames(utils::installed.packages())) {
+      future::plan("multisession", workers = 2)
+      test_consequences(formula = cancer ~ cancerpredmarker + marker,
+                        data = df_binary, parallel = TRUE)
+    }
+  })
 })

--- a/vignettes/dca.Rmd
+++ b/vignettes/dca.Rmd
@@ -256,6 +256,26 @@ dca(cancer ~ marker,
 At a probability threshold of 15%, the net reduction in interventions is about 0.33.
 In other words, at this probability threshold, biopsying patients on the basis of the marker is the equivalent of a strategy that reduced the biopsy rate by 33%, without missing any cancers. 
 
+### Parallel processing
+
+Test consequence statistics (true positives, false positives, etc.) can be
+calculated in parallel across models by installing the `future.apply` package,
+using `future::plan()` to specify the number of cores to use, then setting
+`parallel = TRUE` in the call to `dca()`. This can speed up calculations with
+large datasets, many models, and/or a granular set of thresholds to be tested.
+
+```{r parallel}
+# Use 2 CPU threads (cores)
+future::plan("multisession", workers = 2)
+system.time({
+dca <-
+  dca(cancer ~ famhistory + cancerpredmarker, 
+    data = df_binary, 
+    thresholds = seq(0, 0.35, by = 0.02),
+    parallel = TRUE)
+})
+```
+
 ## Survival Outcomes
 
 ### Motivating Example


### PR DESCRIPTION
Hello,

Here is a small patch to support parallel processing for test_consequences_data_frame(). When it takes longer to calculate those stats, such as larger dataframes, more granular thresholds, and/or more models, this can have a nice speedup and I think the extra complexity is pretty minimal. For my current dataset this lets me go from 7 minutes to 45 seconds to run a dca(), so pretty helpful.

Happy to make any additional changes as preferred.

Cheers,
Chris